### PR TITLE
change error message

### DIFF
--- a/main.go
+++ b/main.go
@@ -85,7 +85,7 @@ func main() {
 		api := slack.New(token)
 		_, err := api.AuthTest()
 		if err != nil {
-			fmt.Println("ERROR: the token you used is not valid...")
+			fmt.Println("ERROR: authentication failed.(" + err.Error() + ")")
 			os.Exit(2)
 		}
 


### PR DESCRIPTION
change invalid token error message.
because invalid token error is output even if network error.


[before]
if invalid token and online.
```
$./slack-dump -t=INVALID_TOKEN
->ERROR: the token you used is not valid...
```
if valid token and offline.
```
$./slack-dump -t=VALID_TOKEN
->ERROR: the token you used is not valid...
```

[after]
if invalid token and online.
```
$./slack-dump -t=INVALID_TOKEN
->ERROR: Authentication failed.(invalid_auth)
```

if valid token and offline.
```
$./slack-dump -t=VALID_TOKEN
->ERROR: Authentication failed.(Post https://slack.com/api/auth.test: dial tcp: lookup slack.com: no such host)
```

---

無効なトークンによるエラーとネットワークエラーの切り分けができればありがたいな、という趣旨のプルリクエストです。
